### PR TITLE
add cmc config repo to pipeline

### DIFF
--- a/configs/central-management-cluster-config.yaml
+++ b/configs/central-management-cluster-config.yaml
@@ -1,0 +1,10 @@
+---
+type: cnct
+uniqueId: central-management-cluster-config
+displayName: central-management-cluster-config Pipeline
+description: Configuration for the Hybrid Stack CMC Cluster
+apiUrl: "https://api.github.com"
+org: samsung-cnct
+repo: central-management-cluster-config
+keepDays: 10
+credentials: github-access


### PR DESCRIPTION
adding the cmc configuration management repo to the pipeline to help build images as needed. 